### PR TITLE
#5 Replace spinner with combo box

### DIFF
--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/ui/OnSelectionChangedListener.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/ui/OnSelectionChangedListener.kt
@@ -1,0 +1,27 @@
+package by.overpass.svgtocomposeintellij.ui
+
+import javax.swing.ComboBoxModel
+import javax.swing.event.ListDataEvent
+import javax.swing.event.ListDataListener
+
+class OnSelectionChangedListener<T>(
+    private val model: ComboBoxModel<T>,
+    private val onSelectionChanged: (T) -> Unit,
+) : ListDataListener {
+
+    override fun intervalAdded(e: ListDataEvent?) {
+        // do nothing
+    }
+
+    override fun intervalRemoved(e: ListDataEvent?) {
+        // do nothing
+    }
+
+    override fun contentsChanged(e: ListDataEvent?) {
+        onSelectionChanged(model.selectedItem as T)
+    }
+}
+
+fun <T> ComboBoxModel<T>.onSelected(onSelected: (T) -> Unit) {
+    addListDataListener(OnSelectionChangedListener(this, onSelected))
+}

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/ui/SvgToComposeWizardStep.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/ui/SvgToComposeWizardStep.kt
@@ -8,16 +8,17 @@ import com.android.tools.idea.observable.core.ObservableBool
 import com.android.tools.idea.observable.core.StringProperty
 import com.android.tools.idea.wizard.model.ModelWizardStep
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
+import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.ui.EnumComboBoxModel
 import com.intellij.ui.components.JBTextField
 import com.intellij.ui.layout.CellBuilder
 import com.intellij.ui.layout.Row
 import com.intellij.ui.layout.panel
+import com.intellij.ui.layout.toNullable
 import org.jetbrains.kotlin.idea.core.util.onTextChange
 import java.io.File
 import javax.swing.JComponent
-import javax.swing.JSpinner
-import javax.swing.SpinnerListModel
 
 class SvgToComposeWizardStep(
     model: SvgToComposeWizardViewModel,
@@ -66,7 +67,7 @@ class SvgToComposeWizardStep(
         }
         row {
             label("Vector image type")
-            vectorTypeSpinner(model.vectorImageType, VectorType.values())
+            vectorTypeComboBox(model.vectorImageType)
         }
         row {
             label("All assets property name")
@@ -128,19 +129,10 @@ private fun fileChooserDescriptor(
     chooseMultiple,
 )
 
-private fun Row.vectorTypeSpinner(
-    prop: ObjectValueProperty<VectorType>,
-    vectorTypes: Array<VectorType>
-): CellBuilder<JSpinner> {
-    val jSpinner = JSpinner()
-    jSpinner.model = SpinnerListModel(vectorTypes)
-    return component(jSpinner).withBinding(
-        { spinner ->
-            spinner.value as VectorType
-        },
-        { spinner, vectorType ->
-            spinner.value = vectorType
-        },
-        prop.toBinding(),
-    )
+private fun Row.vectorTypeComboBox(prop: ObjectValueProperty<VectorType>): CellBuilder<ComboBox<VectorType>> {
+    val comboBoxModel = EnumComboBoxModel(VectorType::class.java)
+    comboBoxModel.onSelected {
+        prop.set(it)
+    }
+    return comboBox(comboBoxModel, prop.toBinding().toNullable())
 }

--- a/src/test/java/by/overpass/svgtocomposeintellij/ui/OnSelectedTest.kt
+++ b/src/test/java/by/overpass/svgtocomposeintellij/ui/OnSelectedTest.kt
@@ -1,0 +1,21 @@
+package by.overpass.svgtocomposeintellij.ui
+
+import org.jdesktop.swingx.combobox.ListComboBoxModel
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class OnSelectedTest {
+
+    private val model = ListComboBoxModel<Unit>(mutableListOf())
+
+    @Test
+    fun `test callback triggered when model updated`() {
+        val mockOnSelected = mock<(Any) -> Unit>()
+
+        model.onSelected(mockOnSelected)
+        model.selectedItem = Unit
+
+        verify(mockOnSelected).invoke(Unit)
+    }
+}

--- a/src/test/java/by/overpass/svgtocomposeintellij/ui/OnSelectionChangedListenerTest.kt
+++ b/src/test/java/by/overpass/svgtocomposeintellij/ui/OnSelectionChangedListenerTest.kt
@@ -1,0 +1,42 @@
+package by.overpass.svgtocomposeintellij.ui
+
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import javax.swing.ComboBoxModel
+import javax.swing.event.ListDataEvent
+
+class OnSelectionChangedListenerTest {
+
+    private val mockModel = mock<ComboBoxModel<Any>>()
+    private val mockOnSelectionChanged = mock<(Any) -> Unit>()
+    private val mockEvent = mock<ListDataEvent>()
+
+    private val listener = OnSelectionChangedListener(mockModel, mockOnSelectionChanged)
+
+
+    @Test
+    fun `test callback not triggered when interval added`() {
+        listener.intervalAdded(mockEvent)
+
+        verifyNoInteractions(mockOnSelectionChanged)
+    }
+
+    @Test
+    fun `test callback not triggered when interval removed`() {
+        listener.intervalRemoved(mockEvent)
+
+        verifyNoInteractions(mockOnSelectionChanged)
+    }
+
+    @Test
+    fun `test callback triggered when contents changed`() {
+        whenever(mockModel.selectedItem).thenReturn(Unit)
+
+        listener.contentsChanged(mockEvent)
+
+        verify(mockOnSelectionChanged).invoke(Unit)
+    }
+}


### PR DESCRIPTION
### Problem
The `VectorTypeSpinner` didn't work as expected. The selected value was always SVG, that's why icons couldn't be generated from  Android XML vector drawables.

### Solution
The non-working `VectorTypeSpinner` was replaced with a working `ComboBox` element