### PR TITLE
Android Studio Electric Eel 2022.1.1 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '1.9.0'
+    id 'org.jetbrains.intellij' version '1.12.0'
     id 'org.jetbrains.kotlin.jvm' version '1.7.20'
     id 'io.gitlab.arturbosch.detekt' version '1.21.0'
 }
 
 group 'by.overpass'
-version '0.5'
+version '0.6'
 
 repositories {
     mavenCentral()
@@ -32,8 +32,14 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version.set("213.7172.25")
+    version.set("221.6008.13")
     plugins.set(['java', 'Kotlin'])
+}
+
+kotlin {
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of("11"))
+    }
 }
 
 signPlugin {
@@ -48,8 +54,7 @@ publishPlugin {
 
 patchPluginXml {
     changeNotes.set("""
-      A crash on Android Studio Dolphin fixed;
-      UI tweaks.
+        Android Studio Electric Eel | 2022.1.1 support
       """)
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
https://github.com/overpas/svg-to-compose-intellij/issues/51 Executed JUnit tests and did manual test by importing plugin zip v0.6 to android studio and generate icons. 

![image](https://user-images.githubusercontent.com/6584143/212954943-6aa85d64-a8c3-4e25-a520-8a250392a404.png)
