### PR TITLE
Update until build 232.7295.16 and update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 plugins {
     id 'java'
     id 'org.jetbrains.intellij' version '1.13.3'
-    id 'org.jetbrains.kotlin.jvm' version '1.8.10'
-    id 'io.gitlab.arturbosch.detekt' version '1.22.0'
+    id 'org.jetbrains.kotlin.jvm' version '1.8.22'
+    id 'io.gitlab.arturbosch.detekt' version '1.23.0'
 }
 
 group 'by.overpass'
-version '0.9'
+version '0.10'
 
 repositories {
     mavenCentral()
@@ -19,15 +19,14 @@ ext {
 }
 
 dependencies {
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.10'
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
-    implementation "org.jetbrains.kotlin:kotlin-reflect:1.8.10"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1'
+    implementation "org.jetbrains.kotlin:kotlin-reflect:1.8.22"
     implementation('com.github.DevSrSouza:svg-to-compose:0.8.1') {
         exclude group: 'xerces', module: 'xercesImpl'
         exclude group: 'xml-apis', module: 'xml-apis'
     }
     testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.mockito.kotlin:mockito-kotlin:4.1.0"
+    testImplementation "org.mockito.kotlin:mockito-kotlin:5.0.0"
 }
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
@@ -55,7 +54,7 @@ publishPlugin {
 tasks {
     patchPluginXml {
         sinceBuild.set("221.6008.13")
-        untilBuild.set("231.8109.175")
+        untilBuild.set("232.7295.16")
     }
 }
 


### PR DESCRIPTION
Closes #78

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the project dependencies and plugin configuration.

### Detailed summary
- Upgraded Kotlin version from 1.8.10 to 1.8.22.
- Upgraded kotlinx-coroutines-core version from 1.6.4 to 1.7.1.
- Upgraded Detekt plugin version from 1.22.0 to 1.23.0.
- Upgraded Mockito-Kotlin version from 4.1.0 to 5.0.0.
- Updated IntelliJ plugin configuration to support newer build versions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->