### PR TITLE
Update until build 232.9921.28

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'by.overpass'
-version '0.11'
+version '0.12'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ publishPlugin {
 tasks {
     patchPluginXml {
         sinceBuild.set("221.6008.13")
-        untilBuild.set("232.9559.34")
+        untilBuild.set("232.9921.28")
     }
 }
 


### PR DESCRIPTION
Closes #93

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version number and the untilBuild value in the build.gradle file.

### Detailed summary
- Updated the version number from 0.11 to 0.12
- Updated the untilBuild value from "232.9559.34" to "232.9921.28"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->