### PR TITLE
Compose ImageVector preview

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,17 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
+        jdk:
+          - zulu
+          - corretto
+          - adopt
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: ${{ matrix.jdk }}
+          java-version: 17
       - name: Build
         run: ./gradlew build

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build](https://github.com/overpas/svg-to-compose-intellij/actions/workflows/build.yml/badge.svg)](https://github.com/overpas/svg-to-compose-intellij/actions/workflows/build.yml)
 [![Check IDE compatibility](https://github.com/overpas/svg-to-compose-intellij/actions/workflows/verify.yml/badge.svg)](https://github.com/overpas/svg-to-compose-intellij/actions/workflows/verify.yml)
 
-A simple Android Studio plugin to generate Jetpack Compose ImageVector icons. In fact, it's a wrapper around the [svg-to-compose](https://github.com/DevSrSouza/svg-to-compose) tool.
+A simple Android Studio plugin to generate Jetpack Compose ImageVector icons. In fact, it's a wrapper around the [svg-to-compose](https://github.com/DevSrSouza/svg-to-compose) tool. Also, allows to preview the generated icons.
 
 ## Installation
 Install from [Jetbrains Marketplace](https://plugins.jetbrains.com/plugin/18619-svg-to-compose)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation(libs.compose.multiplatform.file.picker) {
         exclude(group = "org.jetbrains.kotlinx")
     }
+    testImplementation(kotlin("test"))
     testImplementation(libs.junit)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.kotlin.coroutines.test)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.14
+version=0.15
 jvm-version=17
 since-build=232.8660.185
 until-build=241.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ version=0.14
 jvm-version=17
 since-build=232.8660.185
 until-build=241.*
-change-notes=Support Intellij 2024.1; Fix crashes on previous versions
+change-notes=ImageVector icons preview

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/ComposeImageVectorPreviewEditorProvider.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/ComposeImageVectorPreviewEditorProvider.kt
@@ -1,7 +1,9 @@
 package by.overpass.svgtocomposeintellij.preview
 
+import by.overpass.svgtocomposeintellij.Bundle
 import by.overpass.svgtocomposeintellij.preview.data.KotlinFileIconDataParser
 import by.overpass.svgtocomposeintellij.preview.data.imageVectorDeclarationPattern
+import by.overpass.svgtocomposeintellij.preview.presentation.ComposeImageVectorPreviewViewModelImpl
 import by.overpass.svgtocomposeintellij.preview.ui.ComposeImageVectorPreviewEditor
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorPolicy
@@ -12,6 +14,9 @@ import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import org.jetbrains.skiko.MainUIDispatcher
 
 class ComposeImageVectorPreviewEditorProvider : FileEditorProvider, DumbAware {
 
@@ -21,15 +26,20 @@ class ComposeImageVectorPreviewEditorProvider : FileEditorProvider, DumbAware {
 
     override fun createEditor(project: Project, file: VirtualFile): FileEditor {
         val textEditor = TextEditorProvider.getInstance().createEditor(project, file) as TextEditor
+        val coroutineScope = CoroutineScope(MainUIDispatcher + SupervisorJob())
         return TextEditorWithPreview(
             textEditor,
             ComposeImageVectorPreviewEditor(
-                KotlinFileIconDataParser(
-                    file.toNioPath()
-                        .toFile(),
-                )
+                viewModel = ComposeImageVectorPreviewViewModelImpl(
+                    coroutineScope = coroutineScope,
+                    iconDataParser = KotlinFileIconDataParser(
+                        file.toNioPath()
+                            .toFile(),
+                    ),
+                ),
+                coroutineScope = coroutineScope,
             ),
-            "ComposeImageVectorEditor",
+            Bundle.message("preview_editor_title"),
         )
     }
 

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/ComposeImageVectorPreviewEditorProvider.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/ComposeImageVectorPreviewEditorProvider.kt
@@ -1,0 +1,49 @@
+package by.overpass.svgtocomposeintellij.preview
+
+import by.overpass.svgtocomposeintellij.preview.data.KotlinFileIconDataParser
+import by.overpass.svgtocomposeintellij.preview.data.imageVectorDeclarationPattern
+import by.overpass.svgtocomposeintellij.preview.ui.ComposeImageVectorPreviewEditor
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.FileEditorPolicy
+import com.intellij.openapi.fileEditor.FileEditorProvider
+import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.fileEditor.TextEditorWithPreview
+import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+
+class ComposeImageVectorPreviewEditorProvider : FileEditorProvider, DumbAware {
+
+    override fun accept(project: Project, file: VirtualFile): Boolean {
+        return file.containsImageVector()
+    }
+
+    override fun createEditor(project: Project, file: VirtualFile): FileEditor {
+        val textEditor = TextEditorProvider.getInstance().createEditor(project, file) as TextEditor
+        return TextEditorWithPreview(
+            textEditor,
+            ComposeImageVectorPreviewEditor(
+                KotlinFileIconDataParser(
+                    file.toNioPath()
+                        .toFile(),
+                )
+            ),
+            "ComposeImageVectorEditor",
+        )
+    }
+
+    override fun getEditorTypeId(): String = "compose-image-vector-preview-editor"
+
+    override fun getPolicy(): FileEditorPolicy = FileEditorPolicy.HIDE_DEFAULT_EDITOR
+
+    private fun VirtualFile.containsImageVector(): Boolean {
+        return inputStream
+            .bufferedReader()
+            .useLines { lines ->
+                lines.find { line ->
+                    imageVectorDeclarationPattern.containsMatchIn(line)
+                } != null
+            }
+    }
+}

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/ColorConversion.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/ColorConversion.kt
@@ -1,0 +1,19 @@
+package by.overpass.svgtocomposeintellij.preview.data
+
+@Suppress("MagicNumber")
+fun hexToLongColor(hex: String): Long {
+    check(hex.startsWith("0x"))
+    // Remove any leading '0x' characters
+    val hexValue = hex.removePrefix("0x")
+
+    // Parse hex string to separate ARGB components
+    val alpha = hexValue.substring(0, 2).toInt(16)
+    val red = hexValue.substring(2, 4).toInt(16)
+    val green = hexValue.substring(4, 6).toInt(16)
+    val blue = hexValue.substring(6, 8).toInt(16)
+
+    // Combine components into a long color value
+    val color: Long = (alpha.toLong() shl 24) or (red.toLong() shl 16) or (green.toLong() shl 8) or blue.toLong()
+
+    return color
+}

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/IconData.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/IconData.kt
@@ -1,9 +1,9 @@
 package by.overpass.svgtocomposeintellij.preview.data
 
-import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.vector.ImageVector
 
-@Immutable
+@Stable
 data class IconData(
     val name: String,
     val imageVector: ImageVector,

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/IconData.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/IconData.kt
@@ -1,0 +1,10 @@
+package by.overpass.svgtocomposeintellij.preview.data
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.vector.ImageVector
+
+@Immutable
+data class IconData(
+    val name: String,
+    val imageVector: ImageVector,
+)

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/IconDataParser.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/IconDataParser.kt
@@ -1,0 +1,384 @@
+package by.overpass.svgtocomposeintellij.preview.data
+
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.DefaultGroupName
+import androidx.compose.ui.graphics.vector.DefaultPathName
+import androidx.compose.ui.graphics.vector.DefaultStrokeLineMiter
+import androidx.compose.ui.graphics.vector.DefaultStrokeLineWidth
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.PathBuilder
+import androidx.compose.ui.unit.dp
+import java.io.File
+import java.lang.reflect.Modifier
+import java.lang.reflect.Proxy
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val DEFAULT_BLEND_MODE = 5 // SrcIn
+private const val DEFAULT_AUTO_MIRROR = false
+private const val DEFAULT_STROKE_LINE_CAP = 0 // Butt
+private const val DEFAULT_STROKE_JOIN = 0 // Miter
+private const val DEFAULT_PATH_FILL_TYPE = 0 // Non-zero
+private const val DEFAULT_FILL_ALPHA = 0.5f
+private const val DEFAULT_STROKE_ALPHA = 0.5f
+
+interface IconDataParser {
+
+    suspend fun parse(): Result<IconData>
+}
+
+@Suppress("TooManyFunctions")
+class KotlinFileIconDataParser(
+    private val file: File,
+) : IconDataParser {
+
+    private val builderPattern =
+        ("=\\s*Builder\\((?<builderParams>[\\S\\s]*)\\)\\.apply\\s*\\{(?<builderContent>[\\S\\s]*)\\}\\s*\\n\\s*\\" +
+                ".build\\(\\)").toRegex()
+    private val namedParamsPattern =
+        "(?<paramName>\\w+)[\\s\\n]*=[\\s\\n]*(?<paramValue>[\\w.\"()]+)(,|([\\s\\n]*\\)))".toRegex()
+    private val pathOperationPattern = "path\\s*(?<pathParams>\\([\\S\\s]*)?\\{(?<pathContent>[\\S\\s]*)\\}".toRegex()
+
+    private val defaultColor = Color.Unspecified.value.toLong()
+
+    private data class BuilderDefinition(
+        val fullText: String,
+        val builderParams: String,
+        val builderContent: String,
+    )
+
+    private data class NamedParams(
+        val name: String,
+        val value: String,
+    ) {
+
+        fun getFloatValue(): Float {
+            return if (value.endsWith(".dp")) {
+                value.substringBefore(".dp")
+                    .toFloat()
+                    .dp
+                    .value
+            } else {
+                value.toFloat()
+            }
+        }
+    }
+
+    private data class PathOperation(
+        val fullText: String,
+        val pathParams: String?,
+        val pathBuilderContent: String,
+    )
+
+    override suspend fun parse(): Result<IconData> = withContext(Dispatchers.Default) {
+        runCatching<IconData> {
+            val text = file.readText()
+            val name = getIconName(text)
+            val builderDefinition = getBuilderDefinition(text) ?: throw IllegalStateException("Failed to parse icon")
+            val builderParams = getNamedParams(builderDefinition.builderParams)
+            val builder = createBuilderWithParams(builderParams)
+            val pathOperations = getPathOperations(builderDefinition.builderContent)
+            pathOperations.forEach { pathOperation ->
+                val params = pathOperation.pathParams?.let(::getNamedParams) ?: emptyList()
+                val pathBuilderContentOperations = getPathBuilderContentOperations(pathOperation.pathBuilderContent)
+                builder.drawPathWithParams(params) {
+                    pathBuilderContentOperations.forEach { pathBuilderContentOperation ->
+                        perform(pathBuilderContentOperation)
+                    }
+                }
+            }
+            val imageVector = builder.build()
+            IconData(
+                name = name,
+                imageVector = imageVector,
+            )
+        }
+    }
+
+    private fun getIconName(text: String): String {
+        return imageVectorDeclarationPattern.find(text)?.groupValues?.get(2)
+            ?: throw IllegalStateException("Failed to parse icon name")
+    }
+
+    private fun getBuilderDefinition(text: String): BuilderDefinition? {
+        val groups = builderPattern.find(text)?.groups
+        val fullText = groups?.get(0)?.value
+        val builderParams = groups?.get("builderParams")?.value
+        val builderContent = groups?.get("builderContent")?.value
+        if (fullText == null || builderParams == null || builderContent == null) {
+            return null
+        }
+        return BuilderDefinition(
+            fullText = fullText,
+            builderParams = "$builderParams)",
+            builderContent = builderContent.trim { it.isWhitespace() || it == '\n' },
+        )
+    }
+
+    private fun getNamedParams(text: String): List<NamedParams> {
+        return namedParamsPattern.findAll(text)
+            .toList()
+            .map { result ->
+                val name = result.groups["paramName"]?.value!!
+                val value = result.groups["paramValue"]?.value!!
+                NamedParams(
+                    name = name,
+                    value = value,
+                )
+            }
+    }
+
+    @Suppress("MagicNumber")
+    private fun createBuilderWithParams(namedParams: List<NamedParams>): ImageVector.Builder {
+        val builderClass = ImageVector.Builder::class.java
+        val builderConstructor = builderClass.declaredConstructors[3].apply {
+            isAccessible = true
+        }
+        val newInstance = builderConstructor.newInstance(
+            namedParams.find { it.name == "name" }.getStringNameOrDefault(DefaultGroupName),
+            namedParams.find { it.name == "defaultWidth" }?.getFloatValue()!!,
+            namedParams.find { it.name == "defaultHeight" }?.getFloatValue()!!,
+            namedParams.find { it.name == "viewportWidth" }?.getFloatValue()!!,
+            namedParams.find { it.name == "viewportHeight" }?.getFloatValue()!!,
+            namedParams.find { it.name == "tintColor" }.getColorLongValueOrDefault(defaultColor),
+            namedParams.find { it.name == "tintBlendMode" }.getTintBlendModeIntValueOrDefault(DEFAULT_BLEND_MODE),
+            namedParams.find { it.name == "autoMirror" }.getAutoMirrorBooleanValueOrDefault(DEFAULT_AUTO_MIRROR)
+        )
+        return newInstance as ImageVector.Builder
+    }
+
+    private fun NamedParams?.getStringNameOrDefault(default: String): String {
+        return if (this != null) {
+            value.substringBefore("\"").substringAfter("\"")
+        } else {
+            default
+        }
+    }
+
+    private fun NamedParams?.getColorLongValueOrDefault(default: Long): Long {
+        return if (this != null) {
+            getColorLongValueOrDefault(value, default)
+        } else {
+            default
+        }
+    }
+
+    private fun NamedParams?.getTintBlendModeIntValueOrDefault(default: Int): Int {
+        return if (this != null) {
+            val blendModes = BlendMode::class.java
+                .declaredFields
+                .filter { Modifier.isStatic(it.modifiers) }
+            val currentValue = if (value.contains('.')) {
+                value.substringAfter('.')
+            } else {
+                value
+            }
+            blendModes.find { it.name == currentValue }
+                ?.apply {
+                    isAccessible = true
+                }
+                ?.getInt(null)
+                ?: default
+        } else {
+            default
+        }
+    }
+
+    private fun NamedParams?.getAutoMirrorBooleanValueOrDefault(default: Boolean): Boolean {
+        return if (this != null) {
+            value.toBoolean()
+        } else {
+            default
+        }
+    }
+
+    // Can be Color(0x00000000) or Color.Black
+    private fun getColorLongValueOrDefault(text: String, default: Long): Long {
+        return if (text.contains("(")) {
+            text.substringAfter("(")
+                .substringBefore(")")
+                .let(::hexToLongColor)
+        } else if (text.contains(".")) {
+            val colorText = text.substringAfter(".")
+            Color::class.java
+                .declaredFields
+                .find { it.name == colorText }
+                ?.apply {
+                    isAccessible = true
+                }
+                ?.getLong(null)
+                ?: default
+        } else {
+            default
+        }
+    }
+
+    private fun getPathOperations(text: String): List<PathOperation> {
+        return pathOperationPattern.findAll(text)
+            .toList()
+            .map { result ->
+                val fullText = result.groups[0]?.value
+                val pathParams = result.groups["pathParams"]
+                    ?.value
+                    ?.trimStart { it.isWhitespace() || it == '(' || it == '\n' }
+                val pathContent = result.groups["pathContent"]
+                    ?.value
+                    ?.trim { it.isWhitespace() || it == '\n' }
+                if (fullText == null || pathContent == null) {
+                    return emptyList()
+                }
+                PathOperation(
+                    fullText = fullText,
+                    pathParams = pathParams,
+                    pathBuilderContent = pathContent + "\n",
+                )
+            }
+    }
+
+    private inline fun ImageVector.Builder.drawPathWithParams(
+        namedParams: List<NamedParams>,
+        crossinline pathBuilderContent: PathBuilder.() -> Unit = {},
+    ) {
+        val pathMethod = Class.forName("androidx.compose.ui.graphics.vector.ImageVectorKt")
+            .declaredMethods
+            .find {
+                it.name.contains("path") && it.parameters.last().type.name == "kotlin.jvm.functions.Function1"
+            }
+            ?.apply {
+                isAccessible = true
+            }
+        val functionClass = Class.forName("kotlin.jvm.functions.Function1")
+        val pathBuilderProxy = Proxy.newProxyInstance(
+            functionClass.getClassLoader(),
+            arrayOf<Class<*>>(functionClass)
+        ) { _, _, args -> // Handle the invocations
+            val pathBuilder = args[0] as PathBuilder
+            pathBuilder.pathBuilderContent()
+        }
+        pathMethod?.invoke(
+            null,
+            this,
+            namedParams.find { it.name == "name" }.getStringNameOrDefault(DefaultPathName),
+            namedParams.find { it.name == "fill" }.getBrushOrDefault(null),
+            namedParams.find { it.name == "fillAlpha" }?.getFloatValue() ?: DEFAULT_FILL_ALPHA,
+            namedParams.find { it.name == "stroke" }.getBrushOrDefault(null),
+            namedParams.find { it.name == "strokeAlpha" }?.getFloatValue() ?: DEFAULT_STROKE_ALPHA,
+            namedParams.find { it.name == "strokeLineWidth" }?.getFloatValue() ?: DefaultStrokeLineWidth,
+            namedParams.find { it.name == "strokeLineCap" }.getStrokeLineCapIntOrDefault(DEFAULT_STROKE_LINE_CAP),
+            namedParams.find { it.name == "strokeLineJoin" }.getStrokeJoinIntOrDefault(DEFAULT_STROKE_JOIN),
+            namedParams.find { it.name == "strokeLineMiter" }?.getFloatValue() ?: DefaultStrokeLineMiter,
+            namedParams.find { it.name == "pathFillType" }.getPathFillTypeIntOrDefault(DEFAULT_PATH_FILL_TYPE),
+            pathBuilderProxy
+        )
+    }
+
+    private fun NamedParams?.getBrushOrDefault(default: Brush?): Brush? {
+        return if (this != null) {
+            if (value.contains("SolidColor")) {
+                val colorValue = value.substringAfter("SolidColor(").substringBeforeLast(")")
+                SolidColor(
+                    Color(
+                        NamedParams("temp", colorValue)
+                            .getColorLongValueOrDefault(defaultColor),
+                    ),
+                )
+            } else {
+                default
+            }
+        } else {
+            default
+        }
+    }
+
+    private fun NamedParams?.getStrokeLineCapIntOrDefault(default: Int): Int {
+        return if (this != null) {
+            val strokeLineCapText = if (value.contains('.')) {
+                value.substringAfter(".")
+            } else {
+                value
+            }
+            StrokeCap::class.java
+                .declaredFields
+                .find { it.name == strokeLineCapText }
+                ?.apply {
+                    isAccessible = true
+                }
+                ?.getInt(null)
+                ?: default
+        } else {
+            default
+        }
+    }
+
+    private fun NamedParams?.getStrokeJoinIntOrDefault(default: Int): Int {
+        return if (this != null) {
+            val strokeJoinText = if (value.contains('.')) {
+                value.substringAfter(".")
+            } else {
+                value
+            }
+            StrokeJoin::class.java
+                .declaredFields
+                .find { it.name == strokeJoinText }
+                ?.apply {
+                    isAccessible = true
+                }
+                ?.getInt(null)
+                ?: default
+        } else {
+            default
+        }
+    }
+
+    private fun NamedParams?.getPathFillTypeIntOrDefault(default: Int): Int {
+        return if (this != null) {
+            val pathFillTypeText = if (value.contains('.')) {
+                value.substringAfter(".")
+            } else {
+                value
+            }
+            PathFillType::class.java
+                .declaredFields
+                .find { it.name == pathFillTypeText }
+                ?.apply {
+                    isAccessible = true
+                }
+                ?.getInt(null)
+                ?: default
+        } else {
+            default
+        }
+    }
+
+    private fun getPathBuilderContentOperations(text: String): List<String> {
+        return text.split('\n')
+            .map { it.trim() }
+    }
+
+    @Suppress("SpreadOperator")
+    private fun PathBuilder.perform(pathBuilderOperation: String) {
+        val pathBuilderClass = PathBuilder::class.java
+        val operationString = pathBuilderOperation.substringBefore('(')
+        val paramsString = pathBuilderOperation.substringAfter('(').substringBefore(')')
+        pathBuilderClass.methods
+            .find { it.name == operationString }
+            ?.invoke(
+                this,
+                *getPathBuilderOperationParams(paramsString)
+            )
+    }
+
+    private fun getPathBuilderOperationParams(paramsString: String): Array<Any> {
+        if (paramsString.isBlank()) return emptyArray()
+        return paramsString.split(',')
+            .map { it.trim() }
+            .map { it.toBooleanStrictOrNull() ?: it.toFloat() }
+            .toTypedArray()
+    }
+}

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/IconDataParser.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/IconDataParser.kt
@@ -99,6 +99,8 @@ class KotlinFileIconDataParser(
                 imageVector = imageVector,
             )
         }
+    }.onFailure {
+        it.printStackTrace()
     }
 
     private fun getIconName(text: String): String {
@@ -137,9 +139,13 @@ class KotlinFileIconDataParser(
     @Suppress("MagicNumber")
     private fun createBuilderWithParams(namedParams: List<NamedParams>): ImageVector.Builder {
         val builderClass = ImageVector.Builder::class.java
-        val builderConstructor = builderClass.declaredConstructors[3].apply {
-            isAccessible = true
-        }
+        val builderConstructor = builderClass.declaredConstructors
+            .find { constructor ->
+                constructor.parameterCount == 8 && Modifier.isPrivate(constructor.modifiers)
+            }!!
+            .apply {
+                isAccessible = true
+            }
         val newInstance = builderConstructor.newInstance(
             namedParams.find { it.name == "name" }.getStringNameOrDefault(DefaultGroupName),
             namedParams.find { it.name == "defaultWidth" }?.getFloatValue()!!,

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/IconDataParser.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/IconDataParser.kt
@@ -104,7 +104,9 @@ class KotlinFileIconDataParser(
     }
 
     private fun getIconName(text: String): String {
-        return imageVectorDeclarationPattern.find(text)?.groupValues?.get(2)
+        return imageVectorDeclarationPattern.find(text)
+            ?.groupValues
+            ?.get(2)
             ?: throw IllegalStateException("Failed to parse icon name")
     }
 

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/ImageVectorDeclarationPattern.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/ImageVectorDeclarationPattern.kt
@@ -1,3 +1,3 @@
 package by.overpass.svgtocomposeintellij.preview.data
 
-val imageVectorDeclarationPattern = "(\\s|\\.)([\\w\\-`]+):\\s*ImageVector\\s*\\n?".toRegex()
+val imageVectorDeclarationPattern = "val\\s+(\\w+\\.)+([\\w\\-`]+):\\s*ImageVector\\s*\\n?".toRegex()

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/ImageVectorDeclarationPattern.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/ImageVectorDeclarationPattern.kt
@@ -1,0 +1,3 @@
+package by.overpass.svgtocomposeintellij.preview.data
+
+val imageVectorDeclarationPattern = "(\\s|\\.)([\\w\\-`]+):\\s*ImageVector\\s*\\n?".toRegex()

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/presentation/ComposeImageVectorPreviewIntent.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/presentation/ComposeImageVectorPreviewIntent.kt
@@ -1,0 +1,6 @@
+package by.overpass.svgtocomposeintellij.preview.presentation
+
+sealed class ComposeImageVectorPreviewIntent {
+
+    data object ParseFile : ComposeImageVectorPreviewIntent()
+}

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/presentation/ComposeImageVectorPreviewState.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/presentation/ComposeImageVectorPreviewState.kt
@@ -1,0 +1,14 @@
+package by.overpass.svgtocomposeintellij.preview.presentation
+
+import by.overpass.svgtocomposeintellij.preview.data.IconData
+
+sealed class ComposeImageVectorPreviewState {
+
+    data object Rendering : ComposeImageVectorPreviewState()
+
+    data object Error : ComposeImageVectorPreviewState()
+
+    data class Icon(
+        val data: IconData,
+    ): ComposeImageVectorPreviewState()
+}

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/presentation/ComposeImageVectorPreviewViewModel.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/presentation/ComposeImageVectorPreviewViewModel.kt
@@ -29,6 +29,7 @@ class ComposeImageVectorPreviewViewModelImpl(
 
     private fun parseIconData() {
         coroutineScope.launch {
+            state.update { ComposeImageVectorPreviewState.Rendering }
             iconDataParser.parse()
                 .fold(
                     onSuccess = { iconData ->

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/presentation/ComposeImageVectorPreviewViewModel.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/presentation/ComposeImageVectorPreviewViewModel.kt
@@ -1,0 +1,47 @@
+package by.overpass.svgtocomposeintellij.preview.presentation
+
+import by.overpass.svgtocomposeintellij.preview.data.IconDataParser
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+interface ComposeImageVectorPreviewViewModel {
+
+    val state: StateFlow<ComposeImageVectorPreviewState>
+
+    fun dispatch(action: ComposeImageVectorPreviewIntent)
+}
+
+class ComposeImageVectorPreviewViewModelImpl(
+    private val coroutineScope: CoroutineScope,
+    private val iconDataParser: IconDataParser,
+) : ComposeImageVectorPreviewViewModel {
+
+    override val state = MutableStateFlow<ComposeImageVectorPreviewState>(ComposeImageVectorPreviewState.Rendering)
+
+    override fun dispatch(action: ComposeImageVectorPreviewIntent) {
+        when (action) {
+            is ComposeImageVectorPreviewIntent.ParseFile -> parseIconData()
+        }
+    }
+
+    private fun parseIconData() {
+        coroutineScope.launch {
+            iconDataParser.parse()
+                .fold(
+                    onSuccess = { iconData ->
+                        state.update {
+                            ComposeImageVectorPreviewState.Icon(iconData)
+                        }
+                    },
+                    onFailure = {
+                        state.update {
+                            ComposeImageVectorPreviewState.Error
+                        }
+                    }
+                )
+        }
+    }
+}

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/ui/ComposeImageVectorPreview.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/ui/ComposeImageVectorPreview.kt
@@ -1,0 +1,124 @@
+package by.overpass.svgtocomposeintellij.preview.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import by.overpass.svgtocomposeintellij.Bundle
+import by.overpass.svgtocomposeintellij.preview.presentation.ComposeImageVectorPreviewState
+import by.overpass.svgtocomposeintellij.preview.presentation.ComposeImageVectorPreviewViewModel
+import com.intellij.icons.AllIcons
+import com.intellij.ui.JBColor
+import org.jetbrains.jewel.bridge.toComposeColor
+import org.jetbrains.jewel.ui.component.CircularProgressIndicator
+import org.jetbrains.jewel.ui.component.Icon
+import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.component.Typography
+
+@Composable
+fun ComposeImageVectorPreview(viewModel: ComposeImageVectorPreviewViewModel, modifier: Modifier = Modifier) {
+    val bgColor by remember(JBColor.PanelBackground.rgb) {
+        mutableStateOf(JBColor.PanelBackground.toComposeColor())
+    }
+    Box(
+        modifier = modifier.background(color = bgColor),
+    ) {
+        val state by viewModel.state.collectAsState()
+        when (val theState = state) {
+            is ComposeImageVectorPreviewState.Rendering -> {
+                PreviewRendering(Modifier.fillMaxSize())
+            }
+            is ComposeImageVectorPreviewState.Error -> {
+                PreviewError(Modifier.fillMaxSize())
+            }
+            is ComposeImageVectorPreviewState.Icon -> {
+                PreviewIcon(
+                    iconName = theState.data.name,
+                    imageVector = theState.data.imageVector,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreviewRendering(modifier: Modifier = Modifier) {
+    PreviewContent(
+        label = Bundle.message("preview_state_progress"),
+        modifier = modifier,
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.fillMaxSize()
+                .padding(32.dp),
+        )
+    }
+}
+
+@Composable
+private fun PreviewError(modifier: Modifier = Modifier) {
+    PreviewContent(
+        label = Bundle.message("preview_state_error"),
+        modifier = modifier,
+    ) {
+        Icon(
+            resource = "general/error.svg",
+            contentDescription = Bundle.message("preview_state_error_content_description"),
+            iconClass = AllIcons::class.java,
+            modifier = Modifier.fillMaxSize()
+                .padding(32.dp),
+        )
+    }
+}
+
+@Composable
+private fun PreviewIcon(
+    iconName: String,
+    imageVector: ImageVector,
+    modifier: Modifier = Modifier,
+) {
+    PreviewContent(
+        label = iconName,
+        modifier = modifier,
+    ) {
+        Icon(
+            imageVector = imageVector,
+            contentDescription = iconName,
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}
+
+@Composable
+private fun PreviewContent(
+    label: String,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .padding(bottom = 8.dp, top = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            content()
+        }
+        Text(
+            text = label,
+            style = Typography.h2TextStyle(),
+        )
+    }
+}

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/ui/ComposeImageVectorPreview.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/ui/ComposeImageVectorPreview.kt
@@ -1,10 +1,15 @@
 package by.overpass.svgtocomposeintellij.preview.ui
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -30,16 +35,21 @@ fun ComposeImageVectorPreview(viewModel: ComposeImageVectorPreviewViewModel, mod
     val bgColor by remember(JBColor.PanelBackground.rgb) {
         mutableStateOf(JBColor.PanelBackground.toComposeColor())
     }
-    Box(
-        modifier = modifier.background(color = bgColor),
+    PreviewContent(
+        modifier = modifier.background(color = bgColor)
+            .padding(8.dp),
     ) {
         val state by viewModel.state.collectAsState()
         when (val theState = state) {
             is ComposeImageVectorPreviewState.Rendering -> {
-                PreviewRendering(Modifier.fillMaxSize())
+                PreviewRendering(
+                    modifier = Modifier.fillMaxSize(),
+                )
             }
             is ComposeImageVectorPreviewState.Error -> {
-                PreviewError(Modifier.fillMaxSize())
+                PreviewError(
+                    modifier = Modifier.fillMaxSize(),
+                )
             }
             is ComposeImageVectorPreviewState.Icon -> {
                 PreviewIcon(
@@ -53,30 +63,44 @@ fun ComposeImageVectorPreview(viewModel: ComposeImageVectorPreviewViewModel, mod
 }
 
 @Composable
-private fun PreviewRendering(modifier: Modifier = Modifier) {
-    PreviewContent(
-        label = Bundle.message("preview_state_progress"),
+private fun PreviewRendering(
+    modifier: Modifier = Modifier,
+) {
+    Column(
         modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         CircularProgressIndicator(
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier.weight(1f)
+                .fillMaxWidth()
                 .padding(32.dp),
+        )
+        Text(
+            text = Bundle.message("preview_state_progress"),
+            style = Typography.h2TextStyle(),
         )
     }
 }
 
 @Composable
-private fun PreviewError(modifier: Modifier = Modifier) {
-    PreviewContent(
-        label = Bundle.message("preview_state_error"),
+private fun PreviewError(
+    modifier: Modifier = Modifier,
+) {
+    Column(
         modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Icon(
             resource = "general/error.svg",
             contentDescription = Bundle.message("preview_state_error_content_description"),
             iconClass = AllIcons::class.java,
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier.weight(1f)
+                .fillMaxWidth()
                 .padding(32.dp),
+        )
+        Text(
+            text = Bundle.message("preview_state_error"),
+            style = Typography.h2TextStyle(),
         )
     }
 }
@@ -87,38 +111,48 @@ private fun PreviewIcon(
     imageVector: ImageVector,
     modifier: Modifier = Modifier,
 ) {
-    PreviewContent(
-        label = iconName,
+    Column(
         modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Icon(
             imageVector = imageVector,
             contentDescription = iconName,
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+        )
+        Text(
+            text = iconName,
+            style = Typography.h2TextStyle(),
         )
     }
 }
 
 @Composable
 private fun PreviewContent(
-    label: String,
     modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
+    content: @Composable ColumnScope.() -> Unit,
 ) {
     Column(
-        modifier = modifier
-            .padding(bottom = 8.dp, top = 8.dp),
+        modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Box(
-            modifier = Modifier.weight(1f),
-            contentAlignment = Alignment.Center,
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
         ) {
-            content()
+            Icon(
+                resource = "general/notificationWarning.svg",
+                contentDescription = Bundle.message("preview_warning_icon_content_description"),
+                iconClass = AllIcons::class.java,
+                modifier = Modifier.size(16.dp)
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = Bundle.message("preview_warning_text"),
+            )
         }
-        Text(
-            text = label,
-            style = Typography.h2TextStyle(),
-        )
+        content()
     }
 }

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/ui/ComposeImageVectorPreviewEditor.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/ui/ComposeImageVectorPreviewEditor.kt
@@ -3,10 +3,8 @@ package by.overpass.svgtocomposeintellij.preview.ui
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import by.overpass.svgtocomposeintellij.Bundle
-import by.overpass.svgtocomposeintellij.preview.data.IconDataParser
 import by.overpass.svgtocomposeintellij.preview.presentation.ComposeImageVectorPreviewIntent
 import by.overpass.svgtocomposeintellij.preview.presentation.ComposeImageVectorPreviewViewModel
-import by.overpass.svgtocomposeintellij.preview.presentation.ComposeImageVectorPreviewViewModelImpl
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorState
 import com.intellij.openapi.util.UserDataHolderBase
@@ -15,24 +13,17 @@ import java.awt.Dimension
 import java.beans.PropertyChangeListener
 import javax.swing.JComponent
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import org.jetbrains.jewel.bridge.JewelComposePanel
 import org.jetbrains.jewel.bridge.theme.SwingBridgeTheme
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
-import org.jetbrains.skiko.MainUIDispatcher
 
 private const val DEFAULT_WINDOW_DIMENSION = 400
 
 class ComposeImageVectorPreviewEditor(
-    iconDataParser: IconDataParser,
+    private val viewModel: ComposeImageVectorPreviewViewModel,
+    private val coroutineScope: CoroutineScope,
 ) : FileEditor, UserDataHolderBase() {
-
-    private val coroutineScope = CoroutineScope(MainUIDispatcher + SupervisorJob())
-    private val viewModel: ComposeImageVectorPreviewViewModel = ComposeImageVectorPreviewViewModelImpl(
-        coroutineScope = coroutineScope,
-        iconDataParser = iconDataParser,
-    )
 
     @OptIn(ExperimentalJewelApi::class)
     private val component = JewelComposePanel {

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/ui/ComposeImageVectorPreviewEditor.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/ui/ComposeImageVectorPreviewEditor.kt
@@ -1,0 +1,85 @@
+package by.overpass.svgtocomposeintellij.preview.ui
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import by.overpass.svgtocomposeintellij.Bundle
+import by.overpass.svgtocomposeintellij.preview.data.IconDataParser
+import by.overpass.svgtocomposeintellij.preview.presentation.ComposeImageVectorPreviewIntent
+import by.overpass.svgtocomposeintellij.preview.presentation.ComposeImageVectorPreviewViewModel
+import by.overpass.svgtocomposeintellij.preview.presentation.ComposeImageVectorPreviewViewModelImpl
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.FileEditorState
+import com.intellij.openapi.util.UserDataHolderBase
+import com.intellij.util.ui.JBUI
+import java.awt.Dimension
+import java.beans.PropertyChangeListener
+import javax.swing.JComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import org.jetbrains.jewel.bridge.JewelComposePanel
+import org.jetbrains.jewel.bridge.theme.SwingBridgeTheme
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.skiko.MainUIDispatcher
+
+private const val DEFAULT_WINDOW_DIMENSION = 400
+
+class ComposeImageVectorPreviewEditor(
+    iconDataParser: IconDataParser,
+) : FileEditor, UserDataHolderBase() {
+
+    private val coroutineScope = CoroutineScope(MainUIDispatcher + SupervisorJob())
+    private val viewModel: ComposeImageVectorPreviewViewModel = ComposeImageVectorPreviewViewModelImpl(
+        coroutineScope = coroutineScope,
+        iconDataParser = iconDataParser,
+    )
+
+    @OptIn(ExperimentalJewelApi::class)
+    private val component = JewelComposePanel {
+        SwingBridgeTheme {
+            ComposeImageVectorPreview(
+                viewModel = viewModel,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }.apply {
+        // The size doesn't seem to matter, it will be expanded
+        preferredSize = JBUI.size(Dimension(DEFAULT_WINDOW_DIMENSION, DEFAULT_WINDOW_DIMENSION))
+    }
+
+    init {
+        viewModel.dispatch(ComposeImageVectorPreviewIntent.ParseFile)
+    }
+
+    override fun dispose() {
+        coroutineScope.cancel()
+    }
+
+    override fun getComponent(): JComponent = component
+
+    override fun getPreferredFocusedComponent(): JComponent = component
+
+    override fun getName(): String {
+        return Bundle.message("preview_editor_title")
+    }
+
+    override fun setState(state: FileEditorState) {
+        // do nothing
+    }
+
+    override fun isModified(): Boolean {
+        return false
+    }
+
+    override fun isValid(): Boolean {
+        return true
+    }
+
+    override fun addPropertyChangeListener(listener: PropertyChangeListener) {
+        // do nothing
+    }
+
+    override fun removePropertyChangeListener(listener: PropertyChangeListener) {
+        // do nothing
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -4,12 +4,13 @@
     <vendor email="pckeycalculator@gmail.com">overpass</vendor>
 
     <description><![CDATA[
-    <p>Generate Jetpack Compose Vector Icons from SVG files in Intellij IDEA.</p>
+    <p>Generate Jetpack Compose Vector Icons from SVG files in Intellij IDEA and preview them</p>
     <p>This plugin is a wrapper for the <a href="https://github.com/DevSrSouza/svg-to-compose">svg-to-compose tool</a></p>
     <p>Use cases:</p>
     <ul>
         <li>Manipulate dynamic an SVG file in code, you can generate and do source code modifications</li>
         <li>Create an Icon pack similar to how Material Icons works on Compose</li>
+        <li>Preview the generated ImageVector icons
     </ul>
     ]]></description>
 
@@ -20,7 +21,8 @@
     <depends>org.jetbrains.kotlin</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <!-- Add your extensions here -->
+        <fileEditorProvider
+                implementation="by.overpass.svgtocomposeintellij.preview.ComposeImageVectorPreviewEditorProvider"/>
     </extensions>
 
     <resource-bundle>messages.Bundle</resource-bundle>

--- a/src/main/resources/messages/Bundle.properties
+++ b/src/main/resources/messages/Bundle.properties
@@ -10,3 +10,7 @@ generator_vector_images_directory_hint=Vector images directory:
 generator_vector_image_type_hint=Vector image type:
 generator_all_assets_property_hint=All assets property name
 generator_property_invalid_empty_message={0} can't be empty
+preview_state_error=Something went wrong
+preview_state_error_content_description=Error
+preview_state_progress=Rendering...
+preview_editor_title=ImageVector Preview

--- a/src/main/resources/messages/Bundle.properties
+++ b/src/main/resources/messages/Bundle.properties
@@ -14,3 +14,6 @@ preview_state_error=Something went wrong
 preview_state_error_content_description=Error
 preview_state_progress=Rendering...
 preview_editor_title=ImageVector Preview
+preview_refresh_button=Refresh
+preview_warning_icon_content_description=Warning
+preview_warning_text=Actual icon may differ from the preview

--- a/src/test/java/by/overpass/svgtocomposeintellij/preview/data/ColorConversionNegativeTest.kt
+++ b/src/test/java/by/overpass/svgtocomposeintellij/preview/data/ColorConversionNegativeTest.kt
@@ -1,0 +1,39 @@
+package by.overpass.svgtocomposeintellij.preview.data
+
+import kotlin.test.assertFailsWith
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class ColorConversionNegativeTest(
+    private val colorString: String,
+) {
+
+    companion object {
+
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Array<Any>> = listOf(
+            arrayOf(
+                "0b11000000",
+            ),
+            arrayOf(
+                "0x00",
+            ),
+            arrayOf(
+                "abcd",
+            ),
+            arrayOf(
+                "",
+            ),
+        )
+    }
+
+    @Test
+    fun `fails on a strings that doesn't represent a color`() {
+        assertFailsWith<Exception> {
+            hexToLongColor(colorString)
+        }
+    }
+}

--- a/src/test/java/by/overpass/svgtocomposeintellij/preview/data/ColorConversionPositiveTest.kt
+++ b/src/test/java/by/overpass/svgtocomposeintellij/preview/data/ColorConversionPositiveTest.kt
@@ -1,0 +1,48 @@
+package by.overpass.svgtocomposeintellij.preview.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class ColorConversionPositiveTest(
+    private val colorString: String,
+    private val expected: Long,
+) {
+
+    companion object {
+
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Array<Any>> = listOf(
+            arrayOf(
+                "0xFF000000",
+                4278190080L,
+            ),
+            arrayOf(
+                "0x00000000",
+                0L,
+            ),
+            arrayOf(
+                "0xFFFFFFFF",
+                4294967295L,
+            ),
+            arrayOf(
+                "0xff000000",
+                4278190080L,
+            ),
+            arrayOf(
+                "0xffffffff",
+                4294967295L,
+            ),
+        )
+    }
+
+    @Test
+    fun `colors are parsed correctly`() {
+        val actual = hexToLongColor(colorString)
+
+        assertEquals(expected, actual)
+    }
+}

--- a/src/test/java/by/overpass/svgtocomposeintellij/preview/data/KotlinFileIconDataParserTest.kt
+++ b/src/test/java/by/overpass/svgtocomposeintellij/preview/data/KotlinFileIconDataParserTest.kt
@@ -1,0 +1,48 @@
+package by.overpass.svgtocomposeintellij.preview.data
+
+import java.io.File
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+class KotlinFileIconDataParserTest {
+
+    @Test
+    fun `Ab-testing icon is parsed`() = runTest {
+        val file = File("src/test/resources/kotlin/Ab-testing.kt")
+        val parser = KotlinFileIconDataParser(file)
+
+        val actual = parser.parse()
+
+        assert(actual.isSuccess)
+    }
+
+    @Test
+    fun `Note icon is parsed`() = runTest {
+        val file = File("src/test/resources/kotlin/Note.kt")
+        val parser = KotlinFileIconDataParser(file)
+
+        val actual = parser.parse()
+
+        assert(actual.isSuccess)
+    }
+
+    @Test
+    fun `Clear icon is NOT parsed`() = runTest {
+        val file = File("src/test/resources/kotlin/Clear.kt")
+        val parser = KotlinFileIconDataParser(file)
+
+        val actual = parser.parse()
+
+        assert(actual.isFailure)
+    }
+
+    @Test
+    fun `__MyIconPack file is NOT parsed`() = runTest {
+        val file = File("src/test/resources/kotlin/Clear.kt")
+        val parser = KotlinFileIconDataParser(file)
+
+        val actual = parser.parse()
+
+        assert(actual.isFailure)
+    }
+}

--- a/src/test/java/by/overpass/svgtocomposeintellij/preview/presentation/ComposeImageVectorPreviewViewModelImplTest.kt
+++ b/src/test/java/by/overpass/svgtocomposeintellij/preview/presentation/ComposeImageVectorPreviewViewModelImplTest.kt
@@ -1,0 +1,75 @@
+package by.overpass.svgtocomposeintellij.preview.presentation
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import app.cash.turbine.test
+import by.overpass.svgtocomposeintellij.preview.data.IconData
+import by.overpass.svgtocomposeintellij.preview.data.IconDataParser
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class ComposeImageVectorPreviewViewModelImplTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+    private val iconDataParser = mock<IconDataParser>()
+
+    private val viewModel = ComposeImageVectorPreviewViewModelImpl(
+        coroutineScope = testScope,
+        iconDataParser = iconDataParser,
+    )
+
+    @Test
+    fun `initial state is Rendering`() {
+        val actual = viewModel.state.value
+
+        assertEquals(ComposeImageVectorPreviewState.Rendering, actual)
+    }
+
+    @Test
+    fun `ParseFile intent is received - icon is parsed - state is Icon`() = runTest(testDispatcher) {
+        val iconData = IconData(
+            name = "Test",
+            imageVector = ImageVector.Builder(
+                defaultWidth = 10.dp,
+                defaultHeight = 10.dp,
+                viewportWidth = 100f,
+                viewportHeight = 100f,
+            ).build()
+        )
+        val expected = ComposeImageVectorPreviewState.Icon(iconData)
+        whenever(iconDataParser.parse()) doReturn Result.success(iconData)
+
+        viewModel.dispatch(ComposeImageVectorPreviewIntent.ParseFile)
+
+        viewModel.state.test {
+            skipItems(1)
+
+            val actual = awaitItem()
+
+            assertEquals(expected, actual)
+        }
+    }
+
+    @Test
+    fun `ParseFile intent is received - icon is NOT parsed - state is Error`() = runTest(testDispatcher) {
+        val expected = ComposeImageVectorPreviewState.Error
+        whenever(iconDataParser.parse()) doReturn Result.failure(IllegalStateException("Test exception"))
+
+        viewModel.dispatch(ComposeImageVectorPreviewIntent.ParseFile)
+
+        viewModel.state.test {
+            skipItems(1)
+
+            val actual = awaitItem()
+
+            assertEquals(expected, actual)
+        }
+    }
+}

--- a/src/test/resources/kotlin/Ab-testing.kt
+++ b/src/test/resources/kotlin/Ab-testing.kt
@@ -1,0 +1,69 @@
+package icons.myiconpack
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import icons.MyIconPack
+
+public val MyIconPack.`Ab-testing`: ImageVector
+    get() {
+        if (`_ab-testing` != null) {
+            return `_ab-testing`!!
+        }
+        `_ab-testing` = Builder(name = "Ab-testing", defaultWidth = 24.0.dp, defaultHeight =
+                24.0.dp, viewportWidth = 24.0f, viewportHeight = 24.0f).apply {
+            path(fill = SolidColor(Color(0xFF000000)), stroke = null, strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                    pathFillType = NonZero) {
+                moveTo(4.0f, 2.0f)
+                arcTo(2.0f, 2.0f, 0.0f, false, false, 2.0f, 4.0f)
+                verticalLineTo(12.0f)
+                horizontalLineTo(4.0f)
+                verticalLineTo(8.0f)
+                horizontalLineTo(6.0f)
+                verticalLineTo(12.0f)
+                horizontalLineTo(8.0f)
+                verticalLineTo(4.0f)
+                arcTo(2.0f, 2.0f, 0.0f, false, false, 6.0f, 2.0f)
+                horizontalLineTo(4.0f)
+                moveTo(4.0f, 4.0f)
+                horizontalLineTo(6.0f)
+                verticalLineTo(6.0f)
+                horizontalLineTo(4.0f)
+                moveTo(22.0f, 15.5f)
+                verticalLineTo(14.0f)
+                arcTo(2.0f, 2.0f, 0.0f, false, false, 20.0f, 12.0f)
+                horizontalLineTo(16.0f)
+                verticalLineTo(22.0f)
+                horizontalLineTo(20.0f)
+                arcTo(2.0f, 2.0f, 0.0f, false, false, 22.0f, 20.0f)
+                verticalLineTo(18.5f)
+                arcTo(1.54f, 1.54f, 0.0f, false, false, 20.5f, 17.0f)
+                arcTo(1.54f, 1.54f, 0.0f, false, false, 22.0f, 15.5f)
+                moveTo(20.0f, 20.0f)
+                horizontalLineTo(18.0f)
+                verticalLineTo(18.0f)
+                horizontalLineTo(20.0f)
+                verticalLineTo(20.0f)
+                moveTo(20.0f, 16.0f)
+                horizontalLineTo(18.0f)
+                verticalLineTo(14.0f)
+                horizontalLineTo(20.0f)
+                moveTo(5.79f, 21.61f)
+                lineTo(4.21f, 20.39f)
+                lineTo(18.21f, 2.39f)
+                lineTo(19.79f, 3.61f)
+                close()
+            }
+        }
+        .build()
+        return `_ab-testing`!!
+    }
+
+private var `_ab-testing`: ImageVector? = null

--- a/src/test/resources/kotlin/Clear.kt
+++ b/src/test/resources/kotlin/Clear.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.icons.outlined
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+public val Icons.Outlined.Clear: ImageVector
+    get() {
+        if (_clear != null) {
+            return _clear!!
+        }
+        _clear = materialIcon(name = "Outlined.Clear") {
+            materialPath {
+                moveTo(19.0f, 6.41f)
+                lineTo(17.59f, 5.0f)
+                lineTo(12.0f, 10.59f)
+                lineTo(6.41f, 5.0f)
+                lineTo(5.0f, 6.41f)
+                lineTo(10.59f, 12.0f)
+                lineTo(5.0f, 17.59f)
+                lineTo(6.41f, 19.0f)
+                lineTo(12.0f, 13.41f)
+                lineTo(17.59f, 19.0f)
+                lineTo(19.0f, 17.59f)
+                lineTo(13.41f, 12.0f)
+                lineTo(19.0f, 6.41f)
+                close()
+            }
+        }
+        return _clear!!
+    }
+
+private var _clear: ImageVector? = null

--- a/src/test/resources/kotlin/Note.kt
+++ b/src/test/resources/kotlin/Note.kt
@@ -1,0 +1,48 @@
+package icons.myiconpack
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import icons.MyIconPack
+
+public val MyIconPack.Note: ImageVector
+    get() {
+        if (_note != null) {
+            return _note!!
+        }
+        _note = Builder(name = "Note", defaultWidth = 48.0.dp, defaultHeight = 48.0.dp,
+                viewportWidth = 960.0f, viewportHeight = 960.0f).apply {
+            path(fill = SolidColor(Color(0xFF000000)), stroke = null, strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                    pathFillType = NonZero) {
+                moveTo(120.0f, 720.0f)
+                lineTo(120.0f, 660.0f)
+                lineTo(600.0f, 660.0f)
+                lineTo(600.0f, 720.0f)
+                lineTo(120.0f, 720.0f)
+                close()
+                moveTo(120.0f, 510.0f)
+                lineTo(120.0f, 450.0f)
+                lineTo(840.0f, 450.0f)
+                lineTo(840.0f, 510.0f)
+                lineTo(120.0f, 510.0f)
+                close()
+                moveTo(120.0f, 300.0f)
+                lineTo(120.0f, 240.0f)
+                lineTo(840.0f, 240.0f)
+                lineTo(840.0f, 300.0f)
+                lineTo(120.0f, 300.0f)
+                close()
+            }
+        }
+        .build()
+        return _note!!
+    }
+
+private var _note: ImageVector? = null

--- a/src/test/resources/kotlin/__MyIconPack.kt
+++ b/src/test/resources/kotlin/__MyIconPack.kt
@@ -1,0 +1,18 @@
+package icons
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import icons.myiconpack.`Ab-testing`
+import kotlin.collections.List as ____KtList
+
+public object MyIconPack
+
+private var __AllIcons: ____KtList<ImageVector>? = null
+
+public val MyIconPack.AllIcons: ____KtList<ImageVector>
+  get() {
+    if (__AllIcons != null) {
+      return __AllIcons!!
+    }
+    __AllIcons= listOf(`Ab-testing`)
+    return __AllIcons!!
+  }


### PR DESCRIPTION
Closes #99

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the plugin to support Intellij 2024.1, adds a preview for ImageVector icons, and improves testing and error handling.

### Detailed summary
- Updated plugin version to 0.15
- Added support for ImageVector icons preview
- Introduced new classes for parsing and displaying icons
- Improved color conversion functionality
- Enhanced testing with positive and negative tests
- Updated GitHub workflow to include macOS testing
- Added new resource messages for preview and editor title
- Expanded functionality for parsing and displaying icons in the plugin

> The following files were skipped due to too many changes: `src/test/resources/kotlin/Note.kt`, `src/test/resources/kotlin/Ab-testing.kt`, `src/test/java/by/overpass/svgtocomposeintellij/preview/presentation/ComposeImageVectorPreviewViewModelImplTest.kt`, `src/main/kotlin/by/overpass/svgtocomposeintellij/preview/ComposeImageVectorPreviewEditorProvider.kt`, `src/main/kotlin/by/overpass/svgtocomposeintellij/preview/ui/ComposeImageVectorPreviewEditor.kt`, `src/main/kotlin/by/overpass/svgtocomposeintellij/preview/ui/ComposeImageVectorPreview.kt`, `src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/IconDataParser.kt`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->