### PR TITLE
Allow to view icons from jar files

### DIFF
--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/ComposeImageVectorPreviewEditorProvider.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/ComposeImageVectorPreviewEditorProvider.kt
@@ -2,6 +2,7 @@ package by.overpass.svgtocomposeintellij.preview
 
 import by.overpass.svgtocomposeintellij.Bundle
 import by.overpass.svgtocomposeintellij.preview.data.KotlinFileIconDataParser
+import by.overpass.svgtocomposeintellij.preview.data.asInputStream
 import by.overpass.svgtocomposeintellij.preview.data.imageVectorDeclarationPattern
 import by.overpass.svgtocomposeintellij.preview.presentation.ComposeImageVectorPreviewViewModelImpl
 import by.overpass.svgtocomposeintellij.preview.ui.ComposeImageVectorPreviewEditor
@@ -33,8 +34,7 @@ class ComposeImageVectorPreviewEditorProvider : FileEditorProvider, DumbAware {
                 viewModel = ComposeImageVectorPreviewViewModelImpl(
                     coroutineScope = coroutineScope,
                     iconDataParser = KotlinFileIconDataParser(
-                        file.toNioPath()
-                            .toFile(),
+                        file.asInputStream(),
                     ),
                 ),
                 coroutineScope = coroutineScope,

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/IconDataParser.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/IconDataParser.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.graphics.vector.DefaultStrokeLineWidth
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.PathBuilder
 import androidx.compose.ui.unit.dp
-import java.io.File
+import java.io.InputStream
 import java.lang.reflect.Modifier
 import java.lang.reflect.Proxy
 import kotlinx.coroutines.Dispatchers
@@ -35,7 +35,7 @@ interface IconDataParser {
 
 @Suppress("TooManyFunctions")
 class KotlinFileIconDataParser(
-    private val file: File,
+    private val inputStream: InputStream,
 ) : IconDataParser {
 
     private val builderPattern =
@@ -78,7 +78,7 @@ class KotlinFileIconDataParser(
 
     override suspend fun parse(): Result<IconData> = withContext(Dispatchers.Default) {
         runCatching<IconData> {
-            val text = file.readText()
+            val text = inputStream.reader().readText()
             val name = getIconName(text)
             val builderDefinition = getBuilderDefinition(text) ?: throw IllegalStateException("Failed to parse icon")
             val builderParams = getNamedParams(builderDefinition.builderParams)

--- a/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/VirtualFileExtensions.kt
+++ b/src/main/kotlin/by/overpass/svgtocomposeintellij/preview/data/VirtualFileExtensions.kt
@@ -1,0 +1,17 @@
+package by.overpass.svgtocomposeintellij.preview.data
+
+import com.intellij.openapi.vfs.VirtualFile
+import java.io.InputStream
+import java.net.JarURLConnection
+import java.net.URL
+import kotlin.io.path.inputStream
+
+fun VirtualFile.asInputStream(): InputStream {
+    return if (fileSystem.protocol == "jar") {
+        val url = URL("jar:file:$path")
+        val jarUrlConnection = url.openConnection() as JarURLConnection
+        jarUrlConnection.inputStream
+    } else {
+        toNioPath().inputStream()
+    }
+}

--- a/src/test/java/by/overpass/svgtocomposeintellij/preview/data/KotlinFileIconDataParserTest.kt
+++ b/src/test/java/by/overpass/svgtocomposeintellij/preview/data/KotlinFileIconDataParserTest.kt
@@ -8,8 +8,8 @@ class KotlinFileIconDataParserTest {
 
     @Test
     fun `Ab-testing icon is parsed`() = runTest {
-        val file = File("src/test/resources/kotlin/Ab-testing.kt")
-        val parser = KotlinFileIconDataParser(file)
+        val inputStream = File("src/test/resources/kotlin/Ab-testing.kt").inputStream()
+        val parser = KotlinFileIconDataParser(inputStream)
 
         val actual = parser.parse()
 
@@ -18,8 +18,8 @@ class KotlinFileIconDataParserTest {
 
     @Test
     fun `Note icon is parsed`() = runTest {
-        val file = File("src/test/resources/kotlin/Note.kt")
-        val parser = KotlinFileIconDataParser(file)
+        val inputStream = File("src/test/resources/kotlin/Note.kt").inputStream()
+        val parser = KotlinFileIconDataParser(inputStream)
 
         val actual = parser.parse()
 
@@ -28,8 +28,8 @@ class KotlinFileIconDataParserTest {
 
     @Test
     fun `Clear icon is NOT parsed`() = runTest {
-        val file = File("src/test/resources/kotlin/Clear.kt")
-        val parser = KotlinFileIconDataParser(file)
+        val inputStream = File("src/test/resources/kotlin/Clear.kt").inputStream()
+        val parser = KotlinFileIconDataParser(inputStream)
 
         val actual = parser.parse()
 
@@ -38,8 +38,8 @@ class KotlinFileIconDataParserTest {
 
     @Test
     fun `__MyIconPack file is NOT parsed`() = runTest {
-        val file = File("src/test/resources/kotlin/Clear.kt")
-        val parser = KotlinFileIconDataParser(file)
+        val inputStream = File("src/test/resources/kotlin/Clear.kt").inputStream()
+        val parser = KotlinFileIconDataParser(inputStream)
 
         val actual = parser.parse()
 


### PR DESCRIPTION
Closes #101 

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor code for improved file handling in SVG to Compose plugin.

### Detailed summary
- Added `asInputStream` extension function to `VirtualFile`
- Updated `KotlinFileIconDataParser` to accept `InputStream` instead of `File`
- Updated tests to use `inputStream` instead of `File` for `KotlinFileIconDataParser`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->