### PR TITLE
Update until build and IJ platform

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 # Infrastructure
 jvm-version=21
+org.gradle.jvmargs=-Xmx8g
 # Plugin
 version=0.20
 platform-type=IC

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 # Infrastructure
 jvm-version=21
 # Plugin
-version=0.19
+version=0.20
 platform-type=IC
-platform-version=251.14649.49
+platform-version=251.25410.59
 since-build=242
-until-build=251.*
-change-notes=Update to intellij 2025.1
+until-build=252.*
+change-notes=Update to intellij 2025.2
 plugin-id=by.overpass.svg-to-compose-intellij
 plugin-name=Svg to Compose
 vendor-name=overpass


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `gradle.properties` file for a plugin, increasing the JVM version and memory allocation, and updating the plugin version and compatibility with newer builds of IntelliJ.

### Detailed summary
- Updated `jvm-version` to `21`
- Added `org.gradle.jvmargs` with `-Xmx8g`
- Updated `version` from `0.19` to `0.20`
- Updated `platform-version` from `251.14649.49` to `251.25410.59`
- Changed `until-build` from `251.*` to `252.*`
- Updated `change-notes` to "Update to intellij 2025.2"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->